### PR TITLE
Fix for leaking WebSocketComboWorker actors

### DIFF
--- a/src/main/scala/org/suecarter/websocket/WebSocket.scala
+++ b/src/main/scala/org/suecarter/websocket/WebSocket.scala
@@ -248,6 +248,9 @@ abstract class SimpleWebSocketComboWorker(conn: ActorRef)
   implicit def settings = RoutingSettings.default(actorRefFactory)
   implicit def handler = ExceptionHandler.default
   implicit def rejecter = RejectionHandler.Default
+
+  override def onConnectionClosed(ev: Tcp.ConnectionClosed): Unit = closeLogic(ev)
+
   final def rest: Receive = runRoute(route)
 
   def route: Route


### PR DESCRIPTION
REST pipeline intercepts `Http.ConnectionClosed` messages preventing `closeLogic` from being triggered, this leads to zombie workers piling up.
